### PR TITLE
-u option would use 1208 for files that are eligible.

### DIFF
--- a/src/tagfile.c
+++ b/src/tagfile.c
@@ -334,7 +334,10 @@ static int dofile(const char *name, struct options *opts) {
     }
   } else if (state.ascii_cnt > 0 && state.ascii_cnt == state.total_ascii) {
     tag = 1;
-    ccsid = 819;
+    if (opts->uflag)
+      ccsid = 1208;
+    else
+      ccsid = 819;
     if (st.st_tag.ft_ccsid != ccsid || st.st_tag.ft_txtflag != tag) {
       makechange = 1;
     }


### PR DESCRIPTION
tag pure 819 files as 1208 files if -u is set.